### PR TITLE
Fix broken fact generation when unable to run pg_config on primary

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ The default fact population will not perform checks related to puppet infrastruc
 puppet_status_check::role: primary
 ```
 
+Optionally define the path to `pg_config` if it is not in the standard path.
+
+```
+puppet_status_check::pg_config_path: /usr/pgsql-16/bin/pg_config
+```
+
 ### Disable
 
 To completely disable the collection of `puppet_status_check` facts, uninstall the module or [classify the module](#class-declaration) with the `enabled` parameter:

--- a/lib/shared/puppet_status_check.rb
+++ b/lib/shared/puppet_status_check.rb
@@ -125,7 +125,7 @@ module PuppetStatusCheck
   end
 
   def postgresql_version
-    @pg_version ||= pg_config('version').match(%r{PostgreSQL (\d+)\.(\d+) })
+    @pg_version ||= pg_config('version')&.match(%r{PostgreSQL (\d+)\.(\d+)})
   end
 
   def pg_major_version


### PR DESCRIPTION
Mistake in regex, space at the end, never matches a version.
Also include an example in the docs for setting pg_config_path.